### PR TITLE
Matchmaking

### DIFF
--- a/lib/models.py
+++ b/lib/models.py
@@ -20,6 +20,7 @@ class Group(me.Document):
 class Connection(me.Document):
   sid = me.StringField(require=True, unique=True)
   group = me.StringField(require=True)
+  waiting = me.BooleanField(default=True)
   created = me.DateTimeField()
   meta = {
       'auto_create_index': True,

--- a/lib/routes.py
+++ b/lib/routes.py
@@ -68,7 +68,7 @@ def group_join(data):
 def matchmake(group):
   match = None
   if len(Connection.objects(group=group, waiting=True)) > 1:
-    for conn in Connection.objects:
+    for conn in Connection.objects(group=group, waiting=True):
       if conn.sid != request.sid:
         match = conn.sid
         break

--- a/lib/routes.py
+++ b/lib/routes.py
@@ -108,8 +108,11 @@ def on_join_room(data):
 @socketio.on('leave')
 def on_leave(data):
   room = data['room']
+  return_group = data['return_to']
   leave_room(room)
   send(f'A User left the {room} room', room=room)
+  if return_group:
+    join_room(return_group)
 
 # Global Broadcast.
 @socketio.on("gmessage")

--- a/lib/routes.py
+++ b/lib/routes.py
@@ -112,7 +112,12 @@ def on_leave(data):
   leave_room(room)
   send(f'A User left the {room} room', room=room)
   if return_group:
+    my_conn = Connection.objects(sid=request.sid).first()
+    my_conn.waiting = True
+    my_conn.save()
     join_room(return_group)
+    matchmake(return_group)
+
 
 # Global Broadcast.
 @socketio.on("gmessage")

--- a/lib/routes.py
+++ b/lib/routes.py
@@ -50,15 +50,42 @@ def get_groups():
 @socketio.on('join_group')
 def group_join(data):
   if find_group(data['access_code']):
-    room = data['access_code']
+    group = data['access_code']
+    room = None
     try:
-      Connection(group=room, sid=request.sid, created=datetime.utcnow).save()
-      join_room(room)
+      Connection(group=group, sid=request.sid, created=datetime.utcnow).save()
+      join_room(group)
+      room = matchmake(group)
     except:
       print('something went wrong with adding the connection')
-    send('Successfully Connected to Group', room=room)
+    if room:
+      send(f'Connected to {room}', room=room)
+    else:
+      send('Successfully Connected to Group', room=group)
   else:
     raise ConnectionRefusedError('Group Not Found')
+
+def matchmake(group):
+  match = None
+  if len(Connection.objects(group=group, waiting=True)) > 1:
+    for conn in Connection.objects:
+      if conn.sid != request.sid:
+        match = conn.sid
+        break
+      
+  if match:
+    room = f"room_{request.sid}"
+    join_room(room)
+    join_room(sid=match, room=room)
+    leave_room(room=group)
+    leave_room(sid=match, room=group)
+    my_conn = Connection.objects(sid=request.sid).first()
+    their_conn = Connection.objects(sid=match).first()
+    my_conn.waiting = False
+    my_conn.save()
+    their_conn.waiting = False
+    their_conn.save()
+    return room
 
 # Remove connection from DB upon disconnect
 @socketio.on('disconnect')

--- a/lib/test_server.py
+++ b/lib/test_server.py
@@ -19,6 +19,9 @@ def setup_module():
       created=datetime.utcnow
   ).save()
 
+def teardown_function():
+  Connection.drop_collection()
+
 def teardown_module():
   Group.drop_collection()
   Connection.drop_collection()
@@ -100,7 +103,7 @@ def test_each_connected_client_in_room_sees_when_leaving():
   socketio_test_client.get_received()
   client2_data = socketio_test_client2.get_received()
 
-  socketio_test_client.emit('leave', {'room': 'test'})
+  socketio_test_client.emit('leave', {'room': 'test', 'return_to': ''})
 
   client2_data = socketio_test_client2.get_received()
   client2_message = client2_data[0]['args']
@@ -179,12 +182,12 @@ def test_group_connection_differentiation():
   assert len(Connection.objects) == 1
 
 def test_matchmaking():
-  Connection.objects.delete()
   flask_test_client = app.test_client()
   client1 = socketio.test_client(app, flask_test_client=flask_test_client)
   client2 = socketio.test_client(app, flask_test_client=flask_test_client)
   client3 = socketio.test_client(app, flask_test_client=flask_test_client)
   room_name = f"room_{client2.sid}"
+
   client1.emit('join_group', {'access_code': 'test'})
   data1 = client1.get_received()
 

--- a/lib/test_server.py
+++ b/lib/test_server.py
@@ -246,3 +246,26 @@ def test_leaving_sends_client_back_to_group():
   data1 = client1.get_received()
 
   assert data1[-1]['args'] == 'Test 3'
+
+def test_automatic_matchmaking_after_leaving_room():
+  flask_test_client = app.test_client()
+  client1 = socketio.test_client(app, flask_test_client=flask_test_client)
+  client2 = socketio.test_client(app, flask_test_client=flask_test_client)
+  client3 = socketio.test_client(app, flask_test_client=flask_test_client)
+  room1 = f"room_{client1.sid}"
+  room2 = f"room_{client2.sid}"
+
+  client1.emit('join_group', {'access_code': 'test'})
+  client2.emit('join_group', {'access_code': 'test'})
+  client3.emit('join_group', {'access_code': 'test'})
+
+  client1.emit('leave', {'room': room2, 'return_to': 'test'})
+
+  client3.emit('message', {'message': 'Clients 1 and 3 rule!', 'room': room1})
+  data1 = client1.get_received()
+  data2 = client2.get_received()
+  data3 = client3.get_received()
+
+  assert data1[-1]['args'] == 'Clients 1 and 3 rule!'
+  assert data2[-1]['args'] != 'Clients 1 and 3 rule!'
+  assert data3[-1]['args'] == 'Clients 1 and 3 rule!'


### PR DESCRIPTION
# Description :: User Story
**Rooms :: create, join, leave**
- Adds `matchmake` method
- Expands `leave` functionality to allow rejoining the waiting room
- Adds `waiting` field to `Connection`

## Type of change

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Breaking Change
- [x] Testing

## Notes
Upon joining a group OR leaving a room, matchmaking is invoked. 
  - Connections are filtered by group and a `waiting` status in order to find a match. 
  - `waiting` is set to false for both connections that are matched, preventing them from being considered for other clients that are matchmaking
  - `waiting` is set back to true for the client that leaves the room, allowing them to be matchable

**Not yet implemented:**
- preventing consecutive rematches
- handling disconnects

## Pytest Results

```
collected 11 items                                                                       

lib/test_server.py ........... [100%]

11 passed in 1.09s
```
