### PR TITLE
Prevent rematch

### DIFF
--- a/lib/models.py
+++ b/lib/models.py
@@ -23,6 +23,7 @@ class Connection(me.Document):
   waiting = me.BooleanField(default=True)
   created = me.DateTimeField()
   user_name = me.StringField(default='Anonymous')
+  last_match = me.StringField()
   meta = {
       'auto_create_index': True,
       'index_opts': {'expireAfterSeconds': 43200},

--- a/lib/models.py
+++ b/lib/models.py
@@ -18,7 +18,6 @@ class Group(me.Document):
   }
 
 class Connection(me.Document):
-  user_name = me.StringField()
   sid = me.StringField(require=True, unique=True)
   group = me.StringField(require=True)
   waiting = me.BooleanField(default=True)

--- a/lib/routes.py
+++ b/lib/routes.py
@@ -85,8 +85,8 @@ def matchmake(group):
     their_conn.waiting = False
     their_conn.last_match = my_conn.sid
     their_conn.save()
-    emit('join_room', {'room': room, 'user': my_conn.user_name, 'match': their_conn.user_name}, room=my_conn.sid)
-    emit('join_room', {'room': room, 'user': their_conn.user_name, 'match': my_conn.user_name}, room=their_conn.sid)
+    emit('join_room', {'room': room, 'user': my_conn.user_name, 'match': {'name':their_conn.user_name, 'sid':their_conn.sid}}, room=my_conn.sid)
+    emit('join_room', {'room': room, 'user': their_conn.user_name, 'match': {'name':my_conn.user_name, 'sid':my_conn.sid}}, room=their_conn.sid)
     send(f'{my_conn.user_name} connected.', room=room)
     return room
 

--- a/lib/routes.py
+++ b/lib/routes.py
@@ -69,7 +69,7 @@ def matchmake(group):
   my_conn = Connection.objects(sid=request.sid).first()
   if len(Connection.objects(group=group, waiting=True)) > 1:
     for conn in Connection.objects(group=group, waiting=True):
-      if conn.sid != request.sid and conn.sid != my_conn.last_match:
+      if conn.sid != request.sid and conn.sid != my_conn.last_match and conn.last_match != my_conn.sid:
         match = conn.sid
         break
   if match:

--- a/lib/routes.py
+++ b/lib/routes.py
@@ -66,9 +66,10 @@ def group_join(data):
 
 def matchmake(group):
   match = None
+  my_conn = Connection.objects(sid=request.sid).first()
   if len(Connection.objects(group=group, waiting=True)) > 1:
     for conn in Connection.objects(group=group, waiting=True):
-      if conn.sid != request.sid:
+      if conn.sid != request.sid and conn.sid != my_conn.last_match:
         match = conn.sid
         break
   if match:
@@ -77,11 +78,12 @@ def matchmake(group):
     join_room(sid=match, room=room)
     leave_room(room=group)
     leave_room(sid=match, room=group)
-    my_conn = Connection.objects(sid=request.sid).first()
     their_conn = Connection.objects(sid=match).first()
     my_conn.waiting = False
+    my_conn.last_match = their_conn.sid
     my_conn.save()
     their_conn.waiting = False
+    their_conn.last_match = my_conn.sid
     their_conn.save()
     emit('join_room', {'room': room, 'user': my_conn.user_name, 'match': their_conn.user_name}, room=my_conn.sid)
     emit('join_room', {'room': room, 'user': their_conn.user_name, 'match': my_conn.user_name}, room=their_conn.sid)

--- a/lib/test_server.py
+++ b/lib/test_server.py
@@ -285,8 +285,10 @@ def test_name_sending():
   data1 = client1.get_received()
   data2 = client2.get_received()
 
-  assert data1[1]['args'][0]['match'] == 'Anonymous'
-  assert data2[1]['args'][0]['match'] == 'Client 1'
+  assert data1[1]['args'][0]['match']['name'] == 'Anonymous'
+  assert data1[1]['args'][0]['match']['sid'] == client2.sid
+  assert data2[1]['args'][0]['match']['name'] == 'Client 1'
+  assert data2[1]['args'][0]['match']['sid'] == client1.sid
 
 def test_clients_arent_rematched():
   flask_test_client = app.test_client()

--- a/lib/test_server.py
+++ b/lib/test_server.py
@@ -293,6 +293,7 @@ def test_clients_arent_rematched():
   client1 = socketio.test_client(app, flask_test_client=flask_test_client)
   client2 = socketio.test_client(app, flask_test_client=flask_test_client)
   broadcaster = socketio.test_client(app, flask_test_client=flask_test_client)
+  room1 = f"room_{client1.sid}"
   room2 = f"room_{client2.sid}"
 
   client1.emit('join_group', {'access_code': 'test'})
@@ -305,11 +306,14 @@ def test_clients_arent_rematched():
   assert data2[-1]['args'] == 'Seeable'
 
   client1.emit('leave', {'room': room2, 'return_to': 'test'})
+  data2 = client2.get_received()
   client2.emit('leave', {'room': room2, 'return_to': 'test'})
+
+  broadcaster.emit('message', {'message': 'Unseeable', 'room': room1})
   broadcaster.emit('message', {'message': 'Unseeable', 'room': room2})
 
   data1 = client1.get_received()
   data2 = client2.get_received()
 
-  assert data1[-1]['args'] != 'Unseeable'
-  assert data2[-1]['args'] != 'Unseeable'
+  assert data1 == []
+  assert data2 == []


### PR DESCRIPTION
# Description :: User Story
**Matching :: Prevent Consecutive Rematch**
Prevents two clients from being matched together if they were together in their last room.

## Type of change

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Breaking Change
- [ ] Testing

## Notes
Adds `last_match` to `Connection`
Clients will not match if both of their `last_match` fields match each other. 

## Pytest Results

```
collected 13 items                                                                                                                               
lib/test_server.py ............. [100%]
13 passed in 1.43s
```
